### PR TITLE
Fix PurpleAir extraction to handle private sensors

### DIFF
--- a/etl/extract_purpleair.py
+++ b/etl/extract_purpleair.py
@@ -2,41 +2,78 @@
 
 from __future__ import annotations
 
+import time
+from typing import Any, Dict, List
+
 import requests
-from typing import Any, Dict
 
 from config import Config
 
 
-def extract_purpleair_data() -> Dict[str, Any]:
+def _fetch_multi_sensor(
+    sensor_ids: List[int],
+    read_keys: List[str],
+    fields: str,
+    *,
+    max_retries: int = 5,
+) -> List[Dict[str, Any]]:
+    """Call the PurpleAir multi-sensor endpoint and return parsed rows."""
+
+    if len(sensor_ids) != len(read_keys):
+        raise ValueError("sensor_ids and read_keys must be the same length")
+
+    url = Config.PURPLEAIR_BASE_URL
+    headers = {"X-API-Key": Config.PURPLEAIR_API_KEY}
+    params = {
+        "show_only": ",".join(str(s) for s in sensor_ids),
+        "read_keys": ",".join(read_keys),
+        "fields": fields,
+    }
+
+    delay = 0.5
+    for attempt in range(max_retries):
+        time.sleep(delay)
+        resp = requests.get(url, headers=headers, params=params, timeout=Config.REQUEST_TIMEOUT)
+
+        if resp.status_code == 429:
+            delay *= 2
+            continue
+
+        if resp.status_code >= 400:
+            resp.raise_for_status()
+
+        data = resp.json()
+        field_names = data.get("fields", [])
+        rows = [dict(zip(field_names, row)) for row in data.get("data", [])]
+        return rows
+
+    # If we exhausted retries on 429
+    resp = requests.get(url, headers=headers, params=params, timeout=Config.REQUEST_TIMEOUT)
+    resp.raise_for_status()
+    data = resp.json()
+    field_names = data.get("fields", [])
+    return [dict(zip(field_names, row)) for row in data.get("data", [])]
+
+
+def extract_purpleair_data() -> List[Dict[str, Any]]:
     """Retrieve sensor data from the PurpleAir API.
 
     The function queries the list of sensors defined in the configuration and
-    returns the raw JSON payload from the API. Network errors are not suppressed
-    so that callers can handle them appropriately.
+    returns a list of dictionaries with sensor field values.
     """
 
     sensors = Config.get_private_sensors()
     if not sensors:
         raise ValueError("No PurpleAir sensors configured")
 
-    headers = {"X-API-Key": Config.PURPLEAIR_API_KEY}
-    params = {
-        "show": ",".join(sensors.keys()),
-        "fields": ",".join(Config.PURPLEAIR_FIELDS),
-    }
+    sensor_ids = [int(sid) for sid in sensors.keys()]
+    read_keys = list(sensors.values())
+    fields = ",".join(Config.PURPLEAIR_FIELDS)
 
-    resp = requests.get(
-        Config.PURPLEAIR_BASE_URL,
-        headers=headers,
-        params=params,
-        timeout=Config.REQUEST_TIMEOUT,
-    )
-    resp.raise_for_status()
-    return resp.json()
+    return _fetch_multi_sensor(sensor_ids, read_keys, fields)
 
 
-def extract_purpleair() -> Dict[str, Any]:
+def extract_purpleair() -> List[Dict[str, Any]]:
     """Backward compatible wrapper."""
     return extract_purpleair_data()
 


### PR DESCRIPTION
## Summary
- fetch PurpleAir multi-sensor data using read keys
- retry on rate limiting and return parsed rows

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python etl/main.py` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685542f43b548324bb164fbf8f94e66b