### PR TITLE
Add data quality checks and cron sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Air Quality Rwanda ETL
+
+This project collects PurpleAir sensor data and stores it in a PostgreSQL database.
+
+## Running the ETL
+
+Activate your environment and run:
+
+```bash
+python etl/main.py
+```
+
+Configuration is handled via environment variables in the `.env` file. See `config.py` for details.
+
+## Scheduling with Cron
+
+To run the ETL every 30 minutes you can add the following entry to your crontab:
+
+```cron
+*/30 * * * * cd /path/to/airquality-rwanda && /usr/bin/env python etl/main.py >> logs/cron.log 2>&1
+```
+
+This executes the ETL twice an hour and writes output to `logs/cron.log`.

--- a/crontab.example
+++ b/crontab.example
@@ -1,0 +1,2 @@
+# Run the Air Quality ETL every 30 minutes
+*/30 * * * * cd /path/to/airquality-rwanda && /usr/bin/env python etl/main.py >> logs/cron.log 2>&1

--- a/etl/__init__.py
+++ b/etl/__init__.py
@@ -1,1 +1,11 @@
-# ETL package init
+"""ETL package initialization."""
+
+from .extract_purpleair import extract_purpleair_data
+from .transform import transform_purpleair_data
+from .data_quality import validate_dataframe
+
+__all__ = [
+    "extract_purpleair_data",
+    "transform_purpleair_data",
+    "validate_dataframe",
+]

--- a/etl/data_quality.py
+++ b/etl/data_quality.py
@@ -1,0 +1,48 @@
+"""Data quality validation helpers for the ETL pipeline."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+import pandas as pd
+
+# Columns that must be present and non-null
+REQUIRED_COLUMNS = [
+    "sensor_id",
+    "time_stamp",
+]
+
+# Numeric columns that should not contain negative values
+NON_NEGATIVE_COLUMNS = [
+    "pm1_0_atm",
+    "pm2_5_atm",
+    "pm10_0_atm",
+]
+
+
+def validate_dataframe(df: pd.DataFrame) -> List[str]:
+    """Validate a dataframe and return a list of issues found."""
+    errors: List[str] = []
+
+    if df.empty:
+        return errors
+
+    # Required columns
+    for col in REQUIRED_COLUMNS:
+        if col not in df.columns:
+            errors.append(f"Missing column: {col}")
+        elif df[col].isnull().any():
+            errors.append(f"Null values found in column: {col}")
+
+    # Negative value checks
+    for col in NON_NEGATIVE_COLUMNS:
+        if col in df.columns and (df[col] < 0).any():
+            errors.append(f"Negative values found in column: {col}")
+
+    # Duplicate records check
+    if "sensor_id" in df.columns and "time_stamp" in df.columns:
+        dupes = df.duplicated(subset=["sensor_id", "time_stamp"]).sum()
+        if dupes > 0:
+            errors.append(f"{dupes} duplicate sensor/time_stamp rows")
+
+    return errors


### PR DESCRIPTION
## Summary
- add helper to validate data frames
- integrate data quality checks into ETL
- log warnings when database has duplicates or negative values
- document cron setup and provide example crontab

## Testing
- `python -m py_compile etl/data_quality.py etl/main.py etl/__init__.py`
- `python etl/main.py` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python - <<'EOF'
import pandas as pd
from etl.data_quality import validate_dataframe

df = pd.DataFrame({
    'sensor_id': [1,1],
    'time_stamp': ['2020-01-01','2020-01-01'],
    'pm2_5_atm': [5,-1],
    'pm10_0_atm': [10,11]
})
print(validate_dataframe(df))
EOF

------
https://chatgpt.com/codex/tasks/task_e_685912f0d9108324b0375c56c9c94e0f